### PR TITLE
add exec summary example

### DIFF
--- a/tpm/TPMbook
+++ b/tpm/TPMbook
@@ -1,0 +1,5 @@
+Main Prompt:
+You are a professional author and expert of Technical Program Management, now write a book on the TPM profession. 
+
+Follow up Prompts per chapter:
+You are a professional author and expert of Technical Program Management, write this chapter on the TPM professional in detail: <insert chapter outline>

--- a/tpm/executive_summary.md
+++ b/tpm/executive_summary.md
@@ -1,0 +1,33 @@
+
+# Executive summary slide generation
+
+This example takes raw notes that a Technical Program Manager might have and turns them into a concise executive summary to be shared with stakeholders.
+
+## Prompt settings
+
+| Setting | Value |
+|---|---|
+| Engine | `gpt-35-turbo` / `chatgpt` |
+
+## Prompt text
+
+```
+Use the raw notes below to generate a concise, detailed, and descriptive executive summary. Organize into the template structure below. Avoid repeating the same updates in multiple sections.
+
+Risks:
+- 
+Highlights:
+- 
+Lowlights:
+- 
+Delivered:
+- 
+Upcoming:
+- 
+______________________
+Raw notes:
+  - dump your raw notes here
+  - created ci/cd pipelines
+  - working login screen
+  - etc.
+```


### PR DESCRIPTION
- Adding runbooks that may be relevant to certain roles and professions
- Using TPMs as the first example, with the use case of creating an executive summary given a set of raw notes